### PR TITLE
Make sure tomcat is started.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,3 +14,8 @@
     cache_valid_time: 3600
   with_items: "{{ tomcat8_admin_packages }}"
   when: tomcat8_admin_install
+
+- name: start tomcat8
+  service:
+    name: tomcat8
+    state: started


### PR DESCRIPTION
Handlers fire after all of the roles are done, so tomcat never actually gets started. Add a task so that tomcat starts up. I think this will resolve issues folks have been having with roles that rely on tomcat.