### PR TITLE
Start tomcat later

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -30,9 +30,14 @@
     mode: "640"
   notify: restart tomcat8
 
-- name: start tomcat
+- name: template /etc/default/tomcat8
+  template:
+    src: tomcat-defaults.j2
+    dest: /etc/default/tomcat8
+  notify: restart tomcat8
+
+- name: start tomcat8
   service:
     name: "{{tomcat_service_name}}"
     state: started
     enabled: yes
-  sudo: True

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -14,8 +14,3 @@
     cache_valid_time: 3600
   with_items: "{{ tomcat8_admin_packages }}"
   when: tomcat8_admin_install
-
-- name: start tomcat8
-  service:
-    name: tomcat8
-    state: started


### PR DESCRIPTION
I made a bit of a mistake in #6, and stated tomcat earlier then I should have. This corrects that, so the last thing this role does is make sure tomcat is running.