### PR TITLE
Remove deprecated 'sudo' keyword.

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -19,7 +19,7 @@
     src: server.xml.j2
     dest: "{{tomcat8_home}}/conf/server.xml"
   notify: restart tomcat8
-  sudo: True
+  become: yes
 
 - name: template tomcat-users.xml
   template:
@@ -35,4 +35,4 @@
     name: "{{tomcat_service_name}}"
     state: started
     enabled: yes
-  sudo: True
+  become: yes

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -3,7 +3,7 @@
 - name: group add
   group:
     name: "{{ tomcat8_server_group }}"
-  sudo: True
+  become: yes
 
 
 - name: user add
@@ -12,21 +12,21 @@
     group: "{{ tomcat8_server_group }}"
     home: "{{ tomcat8_user_home }}"
     createhome: no
-  sudo: True
+  become: yes
 
 - name: download and extract
   unarchive:
     src: "{{ tomcat_binary_url }}"
     dest: "/opt/"
     remote_src: yes
-  sudo: True
+  become: yes
 
 - name: symlink install directory
   file:
     src: "{{ tomcat_target_dir }}"
     path: "{{ tomcat8_home }}"
     state: link
-  sudo: True
+  become: yes
 
 - name: change ownership of target installation
   file:
@@ -35,9 +35,9 @@
     group: "{{ tomcat8_server_group }}"
     state: directory
     recurse: yes
-  sudo: True
+  become: yes
 
 - name: systemd
   template: src=tomcat.service.j2 dest=/etc/systemd/system/tomcat8.service
   notify: restart tomcat8
-  sudo: True
+  become: yes


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1329

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

The role currently causes Ansible v. 2.9 to report an error.

```
TASK [Islandora-Devops.tomcat8 : include] **************************************
Tuesday 12 November 2019  15:05:53 -0400 (0:00:00.222)       0:26:43.560 ****** 
fatal: [default]: FAILED! => {"reason": "conflicting action statements: template, sudo\n\nThe error appears to be in '/Users/aoneill/dev/rdm-playbook/roles/external/Islandora-Devops.tomcat8/tasks/config.yml': line 17, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: server configuration\n  ^ here\n"}
```

# What's new?
* Replaced 'sudo' directives with 'become' as per Ansible documentation.



# How should this be tested?

Test a full installation of the playbook with Ansible v. 2.9


# Interested parties
@Islandora-Devops/committers
@rosiel
