### PR TITLE
Update to Tomcat 9 on Ubuntu/Focal64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ansible Role: Tomcat 8 [![Build Status](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat8.svg?branch=main)](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat8)
+# Ansible Role: Tomcat 8 [![Build Status](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat9.svg?branch=main)](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat9)
 
 An Ansible role that installs Tomcat 8 on:
 
@@ -11,52 +11,52 @@ Available variables are listed below, along with default values:
 
 Tomcat packages to install
 ```
-tomcat8_packages:
-  - tomcat8
+tomcat9_packages:
+  - tomcat9
 ```
 
 Tomcat admin packages to install
 ```
-tomcat8_admin_packages:
-  - tomcat8-admin
+tomcat9_admin_packages:
+  - tomcat9-admin
 ```
 
 Directory to install Tomcat into
 ```
-tomcat8_home: /var/lib/tomcat8
+tomcat9_home: /var/lib/tomcat9
 ```
 
 Whether to install the Tomcat administrative interface
 ```
-tomcat8_admin_install: yes
+tomcat9_admin_install: yes
 ```
 
 Tomcat roles
 ```
-tomcat8_roles: []
+tomcat9_roles: []
 ```
 
 Tomcat users
 ```
-tomcat8_users: []
+tomcat9_users: []
 ```
 
 User and group to run Tomcat as
 ```
-tomcat8_server_user: tomcat8
-tomcat8_server_group: tomcat8
+tomcat9_server_user: tomcat
+tomcat9_server_group: tomcat
 ```
 
 Some OS-specific variables are set in vars/* but can be overridden
 ```
-tomcat8_home: /opt/tomcat
+tomcat9_home: /opt/tomcat
 ```
 
 Including these only used by CentOS/RH
 ```
-tomcat8_version: 8.5.27
-tomcat_binary_url:  "http://www-eu.apache.org/dist/tomcat/tomcat-8/v{{ tomcat8_version }}/bin/apache-tomcat-{{ tomcat8_version }}.tar.gz"
-tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat8_version }}"
+tomcat9_version: 8.5.27
+tomcat_binary_url:  "http://www-eu.apache.org/dist/tomcat/tomcat-8/v{{ tomcat9_version }}/bin/apache-tomcat-{{ tomcat9_version }}.tar.gz"
+tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat9_version }}"
 ```
 
 ## Dependencies
@@ -67,7 +67,7 @@ tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat8_version }}"
 
     - hosts: webservers
       roles:
-        - { role: islandora.tomcat8 }
+        - { role: islandora.tomcat9 }
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# Ansible Role: Tomcat 8 [![Build Status](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat9.svg?branch=main)](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat9)
+# Ansible Role: Tomcat [![Build Status](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat9.svg?branch=main)](https://travis-ci.org/Islandora-Devops/ansible-role-tomcat9)
 
-An Ansible role that installs Tomcat 8 on:
-
-* Centos/RHEL 7.x
-* Ubuntu Xenial
+An Ansible role that installs Tomcat on Ubuntu 20.04 Focal Fossa
 
 ## Role Variables
 
@@ -51,14 +48,6 @@ Some OS-specific variables are set in vars/* but can be overridden
 ```
 tomcat9_home: /opt/tomcat
 ```
-
-Including these only used by CentOS/RH
-```
-tomcat9_version: 8.5.27
-tomcat_binary_url:  "http://www-eu.apache.org/dist/tomcat/tomcat-8/v{{ tomcat9_version }}/bin/apache-tomcat-{{ tomcat9_version }}.tar.gz"
-tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat9_version }}"
-```
-
 ## Dependencies
 
   None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,57 +1,57 @@
-tomcat8_packages:
-  - tomcat8
-tomcat8_admin_packages:
-  - tomcat8-admin
+tomcat9_packages:
+  - tomcat9
+tomcat9_admin_packages:
+  - tomcat9-admin
 
-tomcat_service_name:   tomcat8
+tomcat_service_name:   tomcat9
 
-tomcat8_admin_install: yes
+tomcat9_admin_install: yes
 
-tomcat8_roles: []
-tomcat8_users: []
+tomcat9_roles: []
+tomcat9_users: []
 
-tomcat8_server_user: tomcat8
-tomcat8_server_group: tomcat8
-tomcat8_user_home: /home/tomcat8
+tomcat9_server_user: tomcat
+tomcat9_server_group: tomcat
+tomcat9_user_home: /usr/share/tomcat9
 
 # The home directory of the Java development kit (JDK). You need at least
 # JDK version 7. If JAVA_HOME is not set, some common directories for
 # OpenJDK and the Oracle JDK are tried.
-#tomcat8_java_home:
+#tomcat9_java_home:
 
 # You may pass JVM startup parameters to Java here. If unset, the default
 # options will be: -Djava.awt.headless=true -Xmx128m -XX:+UseConcMarkSweepGC
-tomcat8_java_opts:
+tomcat9_java_opts:
   - -Djava.awt.headless=true
   - -Xmx128m
   - -XX:+UseConcMarkSweepGC
 
 # Java compiler to use for translating JavaServer Pages (JSPs). You can use all
 # compilers that are accepted by Ant's build.compiler property.
-#tomcat8_jsp_compiler: javac
+#tomcat9_jsp_compiler: javac
 
 # Use the Java security manager? (yes/no, default: no)
-#tomcat8_tomcat8_security: "no"
+#tomcat9_tomcat9_security: "no"
 
-# Number of days to keep logfiles in /var/log/tomcat8. Default is 14 days.
-#tomcat8_logfile_days: 14
+# Number of days to keep logfiles in /var/log/tomcat9. Default is 14 days.
+#tomcat9_logfile_days: 14
 
 # Whether to compress logfiles older than today's
-#tomcat8_logfile_compress: 1
+#tomcat9_logfile_compress: 1
 
 # Location of the JVM temporary directory
 # WARNING: This directory will be destroyed and recreated at every startup !
-#tomcat8_jvm_tmp: /tmp/tomcat8-temp
+#tomcat9_jvm_tmp: /tmp/tomcat9-temp
 
 # If you run Tomcat on port numbers that are all higher than 1023, then you
 # do not need authbind.  It is used for binding Tomcat to lower port numbers.
 # (yes/no, default: no)
-#tomcat8_authbind: no
+#tomcat9_authbind: no
 
 # Some OS-specific variables are set in vars/* but can be overridden here:
-# tomcat8_home: /opt/tomcat
+# tomcat9_home: /opt/tomcat
 #
 # Tomcat binary to dl and related path (For installing binaries on CentOS/RH)
-# tomcat8_version: 8.5.27
-# tomcat_binary_url:  "http://www-eu.apache.org/dist/tomcat/tomcat-8/v{{ tomcat8_version }}/bin/apache-tomcat-{{ tomcat8_version }}.tar.gz"
-# tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat8_version }}"
+# tomcat9_version: 8.5.27
+# tomcat_binary_url:  "http://www-eu.apache.org/dist/tomcat/tomcat-8/v{{ tomcat9_version }}/bin/apache-tomcat-{{ tomcat9_version }}.tar.gz"
+# tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat9_version }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: tomcat8 restart tomcat8
+- name: tomcat9 restart tomcat9
   service:
-    name: tomcat8
+    name: tomcat9
     state: restarted
-  listen: "restart tomcat8"
+  listen: "restart tomcat9"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,34 +1,34 @@
 ---
 
-- name: template /etc/default/tomcat8
+- name: template /etc/default/tomcat9
   template:
     src: tomcat-defaults.j2
-    dest: /etc/default/tomcat8
-  notify: restart tomcat8
+    dest: /etc/default/tomcat9
+  notify: restart tomcat9
   when: ansible_os_family == 'Debian'
 
-- name: template {{tomcat8_home}}/bin/setenv.sh
+- name: template {{tomcat9_home}}/bin/setenv.sh
   template:
     src: setenv.sh.j2
-    dest: "{{tomcat8_home}}/bin/setenv.sh"
-  notify: restart tomcat8
+    dest: "{{tomcat9_home}}/bin/setenv.sh"
+  notify: restart tomcat9
   when: ansible_os_family == 'RedHat'
 
 - name: server configuration
   template:
     src: server.xml.j2
-    dest: "{{tomcat8_home}}/conf/server.xml"
-  notify: restart tomcat8
+    dest: "{{tomcat9_home}}/conf/server.xml"
+  notify: restart tomcat9
   become: yes
 
 - name: template tomcat-users.xml
   template:
     src: tomcat-users.xml.j2
-    dest: "{{tomcat8_home}}/conf/tomcat-users.xml"
-    owner: "{{ tomcat8_server_user }}"
-    group: "{{ tomcat8_server_group }}"
+    dest: "{{tomcat9_home}}/conf/tomcat-users.xml"
+    owner: "{{ tomcat9_server_user }}"
+    group: "{{ tomcat9_server_group }}"
     mode: "640"
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: start tomcat
   service:

--- a/tasks/define-home.yml
+++ b/tasks/define-home.yml
@@ -4,17 +4,17 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Define tomcat8_home
+- name: Define tomcat9_home
   set_fact:
-    tomcat8_home: "{{ __tomcat8_home }}"
-  when: tomcat8_home is not defined
+    tomcat9_home: "{{ __tomcat9_home }}"
+  when: tomcat9_home is not defined
 
-- name: Define tomcat8_version
+- name: Define tomcat9_version
   set_fact:
-    tomcat8_version: "{{ __tomcat8_version }}"
+    tomcat9_version: "{{ __tomcat9_version }}"
   when:
-    - tomcat8_version is not defined
-    - __tomcat8_version is defined
+    - tomcat9_version is not defined
+    - __tomcat9_version is defined
 
 - name: Define tomcat_binary_url
   set_fact:

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,21 +1,41 @@
 ---
 
-- name: install tomcat8
+- name: install tomcat9
   apt:
     name: "{{ item }}"
     state: present
     cache_valid_time: 3600
-  with_items: "{{ tomcat8_packages }}"
+  with_items: "{{ tomcat9_packages }}"
 
-- name: install tomcat8 admin
+- name: install tomcat9 admin
   apt:
     name: "{{ item }}"
     state: present
     cache_valid_time: 3600
-  with_items: "{{ tomcat8_admin_packages }}"
-  when: tomcat8_admin_install
+  with_items: "{{ tomcat9_admin_packages }}"
+  when: tomcat9_admin_install
 
-- name: start tomcat8
+- name: Create a directory if it does not exist
+  ansible.builtin.file:
+    path: /etc/systemd/system/tomcat9.service.d
+    state: directory
+    mode: '0755'
+
+- name: Create file with sandbox overrides
+  copy:
+    dest: "/etc/systemd/system/tomcat9.service.d/override.conf"
+    content: |
+      [Service]
+      ReadWritePaths={{ fcrepo_home_dir }}/
+      ReadWritePaths={{ blazegraph_home_dir }}/data/
+      ReadWritePaths={{ tomcat9_home }}/fcrepo4-data/
+    mode: '0644'
+
+- name: restart daemon service
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: start tomcat9
   service:
-    name: tomcat8
+    name: tomcat9
     state: started

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -2,15 +2,15 @@
 
 - name: group add
   group:
-    name: "{{ tomcat8_server_group }}"
+    name: "{{ tomcat9_server_group }}"
   become: yes
 
 
 - name: user add
   user:
-    name: "{{ tomcat8_server_user }}"
-    group: "{{ tomcat8_server_group }}"
-    home: "{{ tomcat8_user_home }}"
+    name: "{{ tomcat9_server_user }}"
+    group: "{{ tomcat9_server_group }}"
+    home: "{{ tomcat9_user_home }}"
     createhome: no
   become: yes
 
@@ -24,20 +24,20 @@
 - name: symlink install directory
   file:
     src: "{{ tomcat_target_dir }}"
-    path: "{{ tomcat8_home }}"
+    path: "{{ tomcat9_home }}"
     state: link
   become: yes
 
 - name: change ownership of target installation
   file:
     path: "{{ tomcat_target_dir }}"
-    owner: "{{ tomcat8_server_user }}"
-    group: "{{ tomcat8_server_group }}"
+    owner: "{{ tomcat9_server_user }}"
+    group: "{{ tomcat9_server_group }}"
     state: directory
     recurse: yes
   become: yes
 
 - name: systemd
-  template: src=tomcat.service.j2 dest=/etc/systemd/system/tomcat8.service
-  notify: restart tomcat8
+  template: src=tomcat.service.j2 dest=/etc/systemd/system/tomcat9.service
+  notify: restart tomcat9
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,17 +2,17 @@
 
 - include: "define-home.yml"
   tags:
-    - tomcat8
-    - tomcat8-config
-    - tomcat8-install
+    - tomcat9
+    - tomcat9-config
+    - tomcat9-install
   
 - include: "install-{{ ansible_os_family }}.yml"
   tags:
-    - tomcat8
-    - tomcat8-install
+    - tomcat9
+    - tomcat9-install
 
 - include: config.yml
   static: no
   tags:
-    - tomcat8
-    - tomcat8-config
+    - tomcat9
+    - tomcat9-config

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -88,8 +88,10 @@
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!-- Commented out due to https://access.redhat.com/solutions/4851251 -->
+<!--
     <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
-
+-->
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone

--- a/templates/setenv.sh.j2
+++ b/templates/setenv.sh.j2
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export JAVA_OPTS="$JAVA_OPTS {{ tomcat8_java_opts|join(' ') }}"
+export JAVA_OPTS="$JAVA_OPTS {{ tomcat9_java_opts|join(' ') }}"

--- a/templates/tomcat-defaults.j2
+++ b/templates/tomcat-defaults.j2
@@ -1,24 +1,24 @@
-TOMCAT8_USER={{tomcat8_server_user}}
-TOMCAT8_GROUP={{tomcat8_server_group}}
-{% if tomcat8_java_home is defined %}
-JAVA_HOME="{{tomcat8_java_home}}"
+TOMCAT9_USER={{tomcat9_server_user}}
+TOMCAT9_GROUP={{tomcat9_server_group}}
+{% if tomcat9_java_home is defined %}
+JAVA_HOME="{{tomcat9_java_home}}"
 {% endif %}
-JAVA_OPTS="{{tomcat8_java_opts|join(' ')}}"
-{% if tomcat8_jsp_compiler is defined %}
-JSP_COMPILER="{{tomcat8_jsp_compiler}}"
+JAVA_OPTS="{{tomcat9_java_opts|join(' ')}}"
+{% if tomcat9_jsp_compiler is defined %}
+JSP_COMPILER="{{tomcat9_jsp_compiler}}"
 {% endif %}
-{% if tomcat8_tomcat8_security is defined %}
-TOMCAT8_SECURITY="{{tomcat8_tomcat8_security}}"
+{% if tomcat9_tomcat9_security is defined %}
+TOMCAT9_SECURITY="{{tomcat9_tomcat9_security}}"
 {% endif %}
-{% if tomcat8_logfile_days is defined %}
-LOGFILE_DAYS="{{tomcat8_logfile_days}}"
+{% if tomcat9_logfile_days is defined %}
+LOGFILE_DAYS="{{tomcat9_logfile_days}}"
 {% endif %}
-{% if tomcat8_logfile_compress is defined %}
-LOGFILE_COMPRESS="{{tomcat8_logfile_compress}}"
+{% if tomcat9_logfile_compress is defined %}
+LOGFILE_COMPRESS="{{tomcat9_logfile_compress}}"
 {% endif %}
-{% if tomcat8_jvm_tmp is defined %}
-JVM_TMP="{{tomcat8_jvm_tmp}}"
+{% if tomcat9_jvm_tmp is defined %}
+JVM_TMP="{{tomcat9_jvm_tmp}}"
 {% endif %}
-{% if tomcat8_authbind is defined %}
-AUTHBIND="{{tomcat8_authbind}}"
+{% if tomcat9_authbind is defined %}
+AUTHBIND="{{tomcat9_authbind}}"
 {% endif %}

--- a/templates/tomcat-users.xml.j2
+++ b/templates/tomcat-users.xml.j2
@@ -3,10 +3,10 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
               version="1.0">
-{% for role in tomcat8_roles %}
+{% for role in tomcat9_roles %}
   <role rolename="{{ role }}"/>
 {% endfor %}
-{% for user in tomcat8_users %}
+{% for user in tomcat9_users %}
   <user username="{{ user.username }}" password="{{ user.password }}" roles="{{ user.roles|join(',') }}"/>
 {% endfor %}
 </tomcat-users>

--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -4,17 +4,17 @@ After=network.target
 
 [Service]
 Type=forking
-User={{ tomcat8_server_user }}
-Group={{ tomcat8_server_group }}
+User={{ tomcat9_server_user }}
+Group={{ tomcat9_server_group }}
 
-Environment=CATALINA_PID={{ tomcat8_home }}/{{ tomcat_service_name }}.pid
+Environment=CATALINA_PID={{ tomcat9_home }}/{{ tomcat_service_name }}.pid
 Environment=TOMCAT_JAVA_HOME=/usr/java/default
-Environment=CATALINA_HOME={{ tomcat8_home }}
-Environment=CATALINA_BASE={{ tomcat8_home }}
+Environment=CATALINA_HOME={{ tomcat9_home }}
+Environment=CATALINA_BASE={{ tomcat9_home }}
 Environment=CATALINA_OPTS=
 Environment="JAVA_OPTS=-Dfile.encoding=UTF-8 -Dnet.sf.ehcache.skipUpdateCheck=true -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:MaxPermSize=128m -Xms512m -Xmx512m"
 
-ExecStart={{ tomcat8_home }}/bin/startup.sh
+ExecStart={{ tomcat9_home }}/bin/startup.sh
 ExecStop=/bin/kill -15 $MAINPID
 
 [Install]

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,1 +1,1 @@
-__tomcat8_home: /var/lib/tomcat8
+__tomcat9_home: /var/lib/tomcat9

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
-__tomcat8_home: /opt/tomcat
+__tomcat9_home: /opt/tomcat
 
 # Tomcat binary to dl and related path
-__tomcat8_version: 8.5.28
-__tomcat_binary_url:  "https://archive.apache.org/dist/tomcat/tomcat-8/v{{ tomcat8_version }}/bin/apache-tomcat-{{ tomcat8_version }}.tar.gz"
-__tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat8_version }}"
+__tomcat9_version: 8.5.28
+__tomcat_binary_url:  "https://archive.apache.org/dist/tomcat/tomcat-8/v{{ tomcat9_version }}/bin/apache-tomcat-{{ tomcat9_version }}.tar.gz"
+__tomcat_target_dir:  "/opt/apache-tomcat-{{ tomcat9_version }}"


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64](https://github.com/Islandora/documentation/issues/1792)

# What does this Pull Request do?

Update Tomcat to use the Tomcat 9 packages provided by Ubuntu 20.04. 

# What's new?

* References to Tomcat 8 are replaced with Tomcat 9
* Tomcat user and group changed from tomcat8 to tomcat
* Tomcat9 is sandboxed on Ubuntu 20 from writing to the filesystem except to specified locations. Adds /etc/systemd/system/tomcat9.service.d/override.conf which specifies directories Tomcat can write to. 
* Updated README to reflected updated environment.


# How should this be tested?


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
